### PR TITLE
Node does not terminate on Windows when spawning ES without calling stop()

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ class ElasticsearchLocal {
             return archiver.extractAsync(filename, this.version, this.directories.installationDirectory)
           }).then((binaryPath) => {
             return elasticsearchProcess.start(this.namePrefix, binaryPath, this.port)
-          }).then(() => {
+          }).then((process) => {
+            process.unref()
             return this.checkClusterHealth(this.port, timeoutMilliseconds)
           })
       })


### PR DESCRIPTION
node index.js
`
const NodeEsLocal = require('node-es-local');
(new NodeEsLocal('5.2.0', 9200)).start()
`

On linux the behaviour is always consistent and the node process will always terminate.
On windows, if ES is spawned (not found an elasticsearch node running), the process will not terminate. If the elasticsearch node is already running, the process will terminate.

Solution: calling "process.unref()" when spawning the ES instance solves the problem on windows.